### PR TITLE
[Common] reverted 7643c11 (to maintain Puppi comp w/ CHS)

### DIFF
--- a/Common/python/hltPhase2_JME.py
+++ b/Common/python/hltPhase2_JME.py
@@ -648,7 +648,7 @@ def customize_hltPhase2_JME(process, name='HLTJMESequence'):
     ## Jets: Puppi AK4
     process.hltPuppi = puppi.clone(
       candName = _particleFlowCands,
-      vertexName = _primaryVertices,
+      vertexName = _primaryVerticesGood,
     )
     process.hltAK4PuppiJets = ak4PFJetsPuppi.clone(
       src = _particleFlowCands,
@@ -721,7 +721,7 @@ def customize_hltPhase2_JME(process, name='HLTJMESequence'):
     )
     process.puppiNoLep = puppi.clone(
       candName = 'pfNoLepPUPPI',
-      vertexName = _primaryVertices,
+      vertexName = _primaryVerticesGood,
       PtMaxPhotons = 20.,
     )
     process.hltPuppiForMET = cms.EDProducer('CandViewMerger',

--- a/NTuplizers/interface/L1TPFCandidateCollectionContainer.h
+++ b/NTuplizers/interface/L1TPFCandidateCollectionContainer.h
@@ -1,0 +1,39 @@
+#ifndef JMETriggerAnalysis_L1TPFCandidateCollectionContainer_h
+#define JMETriggerAnalysis_L1TPFCandidateCollectionContainer_h
+
+#include <JMETriggerAnalysis/NTuplizers/interface/VRecoCandidateCollectionContainer.h>
+#include <DataFormats/L1TParticleFlow/interface/PFCandidate.h>
+
+class L1TPFCandidateCollectionContainer : public VRecoCandidateCollectionContainer<l1t::PFCandidate> {
+
+ public:
+  explicit L1TPFCandidateCollectionContainer(const std::string&, const std::string&, const edm::EDGetToken&, const std::string& strCut="", const bool orderByHighestPt=false);
+  virtual ~L1TPFCandidateCollectionContainer() {}
+
+  void clear();
+  void reserve(const size_t);
+  void emplace_back(const l1t::PFCandidate&);
+
+  std::vector<int>& vec_pdgId(){ return pdgId_; }
+  std::vector<float>& vec_pt(){ return pt_; }
+  std::vector<float>& vec_eta(){ return eta_; }
+  std::vector<float>& vec_phi(){ return phi_; }
+  std::vector<float>& vec_mass(){ return mass_; }
+  std::vector<float>& vec_vx(){ return vx_; }
+  std::vector<float>& vec_vy(){ return vy_; }
+  std::vector<float>& vec_vz(){ return vz_; }
+  std::vector<float>& vec_puppiWeight(){ return puppiWeight_; }
+
+ protected:
+  std::vector<int> pdgId_;
+  std::vector<float> pt_;
+  std::vector<float> eta_;
+  std::vector<float> phi_;
+  std::vector<float> mass_;
+  std::vector<float> vx_;
+  std::vector<float> vy_;
+  std::vector<float> vz_;
+  std::vector<float> puppiWeight_;
+};
+
+#endif

--- a/NTuplizers/plugins/JMETriggerNTuple.cc
+++ b/NTuplizers/plugins/JMETriggerNTuple.cc
@@ -11,6 +11,7 @@
 #include "JMETriggerAnalysis/NTuplizers/interface/TriggerResultsContainer.h"
 #include "JMETriggerAnalysis/NTuplizers/interface/ValueContainer.h"
 #include "JMETriggerAnalysis/NTuplizers/interface/RecoVertexCollectionContainer.h"
+#include "JMETriggerAnalysis/NTuplizers/interface/L1TPFCandidateCollectionContainer.h"
 #include "JMETriggerAnalysis/NTuplizers/interface/RecoPFCandidateCollectionContainer.h"
 #include "JMETriggerAnalysis/NTuplizers/interface/PATPackedCandidateCollectionContainer.h"
 #include "JMETriggerAnalysis/NTuplizers/interface/RecoGenJetCollectionContainer.h"
@@ -70,6 +71,7 @@ class JMETriggerNTuple : public edm::one::EDAnalyzer<edm::one::SharedResources> 
   std::vector<ValueContainer<std::vector<float>>> v_vfloatContainer_;
   std::vector<ValueContainer<std::vector<double>>> v_vdoubleContainer_;
   std::vector<RecoVertexCollectionContainer> v_recoVertexCollectionContainer_;
+  std::vector<L1TPFCandidateCollectionContainer> v_l1tPFCandidateCollectionContainer_;
   std::vector<RecoPFCandidateCollectionContainer> v_recoPFCandidateCollectionContainer_;
   std::vector<PATPackedCandidateCollectionContainer> v_patPackedCandidateCollectionContainer_;
   std::vector<RecoGenJetCollectionContainer> v_recoGenJetCollectionContainer_;
@@ -193,6 +195,11 @@ JMETriggerNTuple::JMETriggerNTuple(const edm::ParameterSet& iConfig)
   // reco::VertexCollection
   initCollectionContainer<RecoVertexCollectionContainer, reco::Vertex>
     (iConfig, v_recoVertexCollectionContainer_, "recoVertexCollections", "reco::VertexCollection", stringCutObjectSelectors_map_);
+
+  // l1t::PFCandidateCollection
+  initCollectionContainer<L1TPFCandidateCollectionContainer, l1t::PFCandidate>
+    (iConfig, v_l1tPFCandidateCollectionContainer_, "l1tPFCandidateCollections", "l1t::PFCandidateCollection", stringCutObjectSelectors_map_);
+  for(auto& cc_i : v_l1tPFCandidateCollectionContainer_){ cc_i.orderByHighestPt(true); }
 
   // reco::PFCandidateCollection
   initCollectionContainer<RecoPFCandidateCollectionContainer, reco::PFCandidate>
@@ -334,6 +341,19 @@ JMETriggerNTuple::JMETriggerNTuple(const edm::ParameterSet& iConfig)
     this->addBranch(recoVertexCollectionContainer_i.name()+"_xError", &recoVertexCollectionContainer_i.vec_xError());
     this->addBranch(recoVertexCollectionContainer_i.name()+"_yError", &recoVertexCollectionContainer_i.vec_yError());
     this->addBranch(recoVertexCollectionContainer_i.name()+"_zError", &recoVertexCollectionContainer_i.vec_zError());
+  }
+
+  for(auto& l1tPFCandidateCollectionContainer_i : v_l1tPFCandidateCollectionContainer_){
+
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_pdgId", &l1tPFCandidateCollectionContainer_i.vec_pdgId());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_pt", &l1tPFCandidateCollectionContainer_i.vec_pt());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_eta", &l1tPFCandidateCollectionContainer_i.vec_eta());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_phi", &l1tPFCandidateCollectionContainer_i.vec_phi());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_mass", &l1tPFCandidateCollectionContainer_i.vec_mass());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_vx", &l1tPFCandidateCollectionContainer_i.vec_vx());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_vy", &l1tPFCandidateCollectionContainer_i.vec_vy());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_vz", &l1tPFCandidateCollectionContainer_i.vec_vz());
+    this->addBranch(l1tPFCandidateCollectionContainer_i.name()+"_puppiWeight", &l1tPFCandidateCollectionContainer_i.vec_puppiWeight());
   }
 
   for(auto& recoPFCandidateCollectionContainer_i : v_recoPFCandidateCollectionContainer_){
@@ -632,6 +652,9 @@ void JMETriggerNTuple::analyze(const edm::Event& iEvent, const edm::EventSetup& 
 
   // reco::Vertex
   this->fillCollectionContainer<RecoVertexCollectionContainer, reco::Vertex>(iEvent, v_recoVertexCollectionContainer_, fillCollectionConditionMap_);
+
+  // l1t::PFCandidateCollection
+  this->fillCollectionContainer<L1TPFCandidateCollectionContainer, l1t::PFCandidate>(iEvent, v_l1tPFCandidateCollectionContainer_, fillCollectionConditionMap_);
 
   // reco::PFCandidateCollection
   this->fillCollectionContainer<RecoPFCandidateCollectionContainer, reco::PFCandidate>(iEvent, v_recoPFCandidateCollectionContainer_, fillCollectionConditionMap_);

--- a/NTuplizers/src/L1TPFCandidateCollectionContainer.cc
+++ b/NTuplizers/src/L1TPFCandidateCollectionContainer.cc
@@ -1,0 +1,45 @@
+#include <JMETriggerAnalysis/NTuplizers/interface/L1TPFCandidateCollectionContainer.h>
+
+L1TPFCandidateCollectionContainer::L1TPFCandidateCollectionContainer(
+  const std::string& name, const std::string& inputTagLabel, const edm::EDGetToken& token, const std::string& strCut, const bool orderByHighestPt
+) : VRecoCandidateCollectionContainer(name, inputTagLabel, token, strCut, orderByHighestPt) {
+}
+
+void L1TPFCandidateCollectionContainer::clear(){
+
+  pdgId_.clear();
+  pt_.clear();
+  eta_.clear();
+  phi_.clear();
+  mass_.clear();
+  vx_.clear();
+  vy_.clear();
+  vz_.clear();
+  puppiWeight_.clear();
+}
+
+void L1TPFCandidateCollectionContainer::reserve(const size_t vec_size){
+
+  pdgId_.reserve(vec_size);
+  pt_.reserve(vec_size);
+  eta_.reserve(vec_size);
+  phi_.reserve(vec_size);
+  mass_.reserve(vec_size);
+  vx_.reserve(vec_size);
+  vy_.reserve(vec_size);
+  vz_.reserve(vec_size);
+  puppiWeight_.reserve(vec_size);
+}
+
+void L1TPFCandidateCollectionContainer::emplace_back(const l1t::PFCandidate& obj){
+
+  pdgId_.emplace_back(obj.pdgId());
+  pt_.emplace_back(obj.pt());
+  eta_.emplace_back(obj.eta());
+  phi_.emplace_back(obj.phi());
+  mass_.emplace_back(obj.mass());
+  vx_.emplace_back(obj.vx());
+  vy_.emplace_back(obj.vy());
+  vz_.emplace_back(obj.vz());
+  puppiWeight_.emplace_back(obj.vz());
+}

--- a/NTuplizers/test/jmeTriggerNTuple_cfg.py
+++ b/NTuplizers/test/jmeTriggerNTuple_cfg.py
@@ -131,9 +131,14 @@ process.JMETriggerNTuple = cms.EDAnalyzer('JMETriggerNTuple',
     offlinePrimaryVertices = cms.InputTag('offlineSlimmedPrimaryVertices'),
   ),
 
+  l1tPFCandidateCollections = cms.PSet(
+
+#    l1tPuppi = cms.InputTag('l1pfCandidates', 'Puppi'),
+  ),
+
   recoPFCandidateCollections = cms.PSet(
 
-#    particleFlowTmp = cms.InputTag('particleFlowTmp'),
+#    hltParticleFlow = cms.InputTag('particleFlowTmp'),
 #    hltPuppi = cms.InputTag('hltPuppi'),
 #    hltPuppiForMET = cms.InputTag('hltPuppiForMET'),
   ),


### PR DESCRIPTION
* reverted one change introduced #6, in order to keep the same LV input for CHS and Puppi (at least for now, to be revisited in the future)
* updated `JMETriggerNTuple` with container for collection of `l1t::PFCandidate` objects
