### PR TITLE
[Common] changes needed for running TRK V0 - delete trackTimeValueMapProducer

### DIFF
--- a/Common/python/customizeHLTForPhase2.py
+++ b/Common/python/customizeHLTForPhase2.py
@@ -25,6 +25,7 @@ def customise_hltPhase2_enableTICLInHGCalReconstruction(process):
     # remove modules specific to SIM-assisted reconstruction
     del process.tpClusterProducer
     del process.quickTrackAssociatorByHits
+    del process.trackTimeValueMapProducer
     del process.simPFProducer
 
     process.iterTICLSequence = cms.Sequence(process.iterTICLTask)


### PR DESCRIPTION
- small fix needed to run TRK configuration V0

Error message:
```
An exception of category 'ProductNotFound' occurred while
   [0] Processing  Event run: 1 lumi: 1779 event: 449840 stream: 0
   [1] Running path 'noFilter_PFDeepFlavourPuppi'
   [2] Calling method for module TrackTimeValueMapProducer/'trackTimeValueMapProducer'
Exception Message:
Principal::getByToken: Found zero products matching all criteria
Looking for type: reco::TrackToTrackingParticleAssociator
Looking for module label: quickTrackAssociatorByHits
Looking for productInstanceName:
```