### PR TITLE
updates for Run-3 (incl. updated PFHC for JECs)

### DIFF
--- a/NTuplizers/interface/RecoPFCandidateCollectionContainer.h
+++ b/NTuplizers/interface/RecoPFCandidateCollectionContainer.h
@@ -24,6 +24,8 @@ public:
   std::vector<float>& vec_mass() { return mass_; }
   std::vector<float>& vec_rawEcalEnergy() { return rawEcalEnergy_; }
   std::vector<float>& vec_rawHcalEnergy() { return rawHcalEnergy_; }
+  std::vector<float>& vec_ecalEnergy() { return ecalEnergy_; }
+  std::vector<float>& vec_hcalEnergy() { return hcalEnergy_; }
   std::vector<float>& vec_vx() { return vx_; }
   std::vector<float>& vec_vy() { return vy_; }
   std::vector<float>& vec_vz() { return vz_; }
@@ -36,6 +38,8 @@ protected:
   std::vector<float> mass_;
   std::vector<float> rawEcalEnergy_;
   std::vector<float> rawHcalEnergy_;
+  std::vector<float> ecalEnergy_;
+  std::vector<float> hcalEnergy_;
   std::vector<float> vx_;
   std::vector<float> vy_;
   std::vector<float> vz_;

--- a/NTuplizers/plugins/JMETriggerNTuple.cc
+++ b/NTuplizers/plugins/JMETriggerNTuple.cc
@@ -521,6 +521,10 @@ JMETriggerNTuple::JMETriggerNTuple(const edm::ParameterSet& iConfig)
                     &recoPFCandidateCollectionContainer_i.vec_rawEcalEnergy());
     this->addBranch(recoPFCandidateCollectionContainer_i.name() + "_rawHcalEnergy",
                     &recoPFCandidateCollectionContainer_i.vec_rawHcalEnergy());
+    this->addBranch(recoPFCandidateCollectionContainer_i.name() + "_ecalEnergy",
+                    &recoPFCandidateCollectionContainer_i.vec_ecalEnergy());
+    this->addBranch(recoPFCandidateCollectionContainer_i.name() + "_hcalEnergy",
+                    &recoPFCandidateCollectionContainer_i.vec_hcalEnergy());
     this->addBranch(recoPFCandidateCollectionContainer_i.name() + "_vx",
                     &recoPFCandidateCollectionContainer_i.vec_vx());
     this->addBranch(recoPFCandidateCollectionContainer_i.name() + "_vy",

--- a/NTuplizers/src/RecoPFCandidateCollectionContainer.cc
+++ b/NTuplizers/src/RecoPFCandidateCollectionContainer.cc
@@ -15,6 +15,8 @@ void RecoPFCandidateCollectionContainer::clear() {
   mass_.clear();
   rawEcalEnergy_.clear();
   rawHcalEnergy_.clear();
+  ecalEnergy_.clear();
+  hcalEnergy_.clear();
   vx_.clear();
   vy_.clear();
   vz_.clear();
@@ -28,6 +30,8 @@ void RecoPFCandidateCollectionContainer::reserve(const size_t vec_size) {
   mass_.reserve(vec_size);
   rawEcalEnergy_.reserve(vec_size);
   rawHcalEnergy_.reserve(vec_size);
+  ecalEnergy_.reserve(vec_size);
+  hcalEnergy_.reserve(vec_size);
   vx_.reserve(vec_size);
   vy_.reserve(vec_size);
   vz_.reserve(vec_size);
@@ -41,6 +45,8 @@ void RecoPFCandidateCollectionContainer::emplace_back(const reco::PFCandidate& o
   mass_.emplace_back(obj.mass());
   rawEcalEnergy_.emplace_back(obj.rawEcalEnergy());
   rawHcalEnergy_.emplace_back(obj.rawHcalEnergy());
+  ecalEnergy_.emplace_back(obj.ecalEnergy());
+  hcalEnergy_.emplace_back(obj.hcalEnergy());
   vx_.emplace_back(obj.vx());
   vy_.emplace_back(obj.vy());
   vz_.emplace_back(obj.vz());

--- a/NTuplizers/test/jescJRA_cfg.py
+++ b/NTuplizers/test/jescJRA_cfg.py
@@ -29,11 +29,6 @@ opts.register('lumis', None,
               vpo.VarParsing.varType.string,
               'path to .json with list of luminosity sections')
 
-opts.register('logs', False,
-              vpo.VarParsing.multiplicity.singleton,
-              vpo.VarParsing.varType.bool,
-              'create log files configured via MessageLogger')
-
 opts.register('wantSummary', False,
               vpo.VarParsing.multiplicity.singleton,
               vpo.VarParsing.varType.bool,
@@ -47,17 +42,17 @@ opts.register('wantSummary', False,
 opts.register('reco', 'HLT_GRun',
               vpo.VarParsing.multiplicity.singleton,
               vpo.VarParsing.varType.string,
-              'keyword defining HLT reconstruction')
-
-opts.register('verbosity', 0,
-              vpo.VarParsing.multiplicity.singleton,
-              vpo.VarParsing.varType.int,
-              'level of output verbosity')
+              'keyword to define HLT reconstruction')
 
 opts.register('output', 'out.root',
               vpo.VarParsing.multiplicity.singleton,
               vpo.VarParsing.varType.string,
               'path to output ROOT file')
+
+opts.register('verbosity', 0,
+              vpo.VarParsing.multiplicity.singleton,
+              vpo.VarParsing.varType.int,
+              'level of output verbosity')
 
 opts.parseArguments()
 
@@ -115,17 +110,37 @@ for _modname in sorted(process.paths_()):
 print '-'*108
 
 # remove FastTimerService
-del process.FastTimerService
+if hasattr(process, 'FastTimerService'):
+  del process.FastTimerService
 
 # remove MessageLogger
-del process.MessageLogger
+if hasattr(process, 'MessageLogger'):
+  del process.MessageLogger
 
 ###
-### customizations
+### customisations
 ###
+
+## customised JME collections
 from JMETriggerAnalysis.Common.customise_hlt import *
 process = addPaths_MC_PFClusterJME(process)
 process = addPaths_MC_PFPuppiJME(process)
+
+## ES modules for PF-Hadron Calibrations
+import os
+from CondCore.CondDB.CondDB_cfi import CondDB as _CondDB
+process.pfhcESSource = cms.ESSource('PoolDBESSource',
+  _CondDB.clone(connect = 'sqlite_file:'+os.environ['CMSSW_BASE']+'/src/JMETriggerAnalysis/NTuplizers/data/PFHC_Run3Winter20_HLT_v01.db'),
+  toGet = cms.VPSet(
+    cms.PSet(
+      record = cms.string('PFCalibrationRcd'),
+      tag = cms.string('PFCalibration_HLT_mcRun3_2021'),
+      label = cms.untracked.string('HLT'),
+    ),
+  ),
+)
+process.pfhcESPrefer = cms.ESPrefer('PoolDBESSource', 'pfhcESSource')
+#process.hltParticleFlow.calibrationsLabel = '' # standard label for Offline-PFHC in GT
 
 ###
 ### Jet Response Analyzer (JRA) NTuple
@@ -148,10 +163,9 @@ for algorithm in [
   getattr(process, algorithm).srcRhos = ''
   getattr(process, algorithm).deltaRMax = 0.2
 
-## update process.GlobalTag.globaltag
-#if opts.globalTag is not None:
-#   from Configuration.AlCa.GlobalTag import GlobalTag
-#   process.GlobalTag = GlobalTag(process.GlobalTag, opts.globalTag, '')
+###
+### standard options
+###
 
 # max number of events to be processed
 process.maxEvents.input = opts.maxEvents
@@ -166,74 +180,36 @@ process.options.numberOfStreams = max(opts.numStreams, 0)
 # show cmsRun summary at job completion
 process.options.wantSummary = cms.untracked.bool(opts.wantSummary)
 
+## update process.GlobalTag.globaltag
+#if opts.globalTag is not None:
+#   from Configuration.AlCa.GlobalTag import GlobalTag
+#   process.GlobalTag = GlobalTag(process.GlobalTag, opts.globalTag, '')
+
 # select luminosity sections from .json file
 if opts.lumis is not None:
    import FWCore.PythonUtilities.LumiList as LumiList
    process.source.lumisToProcess = LumiList.LumiList(filename = opts.lumis).getVLuminosityBlockRange()
 
-# create TFileService to be accessed by JRA-NTuple plugin
-process.TFileService = cms.Service('TFileService', fileName = cms.string(opts.output))
-
-# MessageLogger
-if opts.logs:
-   process.MessageLogger = cms.Service('MessageLogger',
-     destinations = cms.untracked.vstring(
-       'cerr',
-       'logError',
-       'logInfo',
-       'logDebug',
-     ),
-     # scram b USER_CXXFLAGS="-DEDM_ML_DEBUG"
-     debugModules = cms.untracked.vstring(
-     ),
-     categories = cms.untracked.vstring(
-       'FwkReport',
-     ),
-     cerr = cms.untracked.PSet(
-       threshold = cms.untracked.string('WARNING'),
-       FwkReport = cms.untracked.PSet(
-         reportEvery = cms.untracked.int32(1),
-       ),
-     ),
-     logError = cms.untracked.PSet(
-       threshold = cms.untracked.string('ERROR'),
-       extension = cms.untracked.string('.txt'),
-       FwkReport = cms.untracked.PSet(
-         reportEvery = cms.untracked.int32(1),
-       ),
-     ),
-     logInfo = cms.untracked.PSet(
-       threshold = cms.untracked.string('INFO'),
-       extension = cms.untracked.string('.txt'),
-       FwkReport = cms.untracked.PSet(
-         reportEvery = cms.untracked.int32(1),
-       ),
-     ),
-     logDebug = cms.untracked.PSet(
-       threshold = cms.untracked.string('DEBUG'),
-       extension = cms.untracked.string('.txt'),
-       FwkReport = cms.untracked.PSet(
-         reportEvery = cms.untracked.int32(1),
-       ),
-     ),
-   )
-
 # input EDM files
-process.source.secondaryFileNames = []
 if opts.inputFiles:
    process.source.fileNames = opts.inputFiles
 else:
    process.source.fileNames = [
-     '/store/mc/Phase2HLTTDRSummer20ReRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/FEVT/PU200_111X_mcRun4_realistic_T15_v1-v2/280000/015FB6F1-59B4-304C-B540-2392A983A97D.root',
+     '/store/mc/Run3Winter20DRMiniAOD/QCD_Pt-15to7000_TuneCP5_Flat_14TeV_pythia8/GEN-SIM-RAW/FlatPU0to80_110X_mcRun3_2021_realistic_v6-v1/100000/07634100-A880-4E4D-BAA3-D9C0B5356C2D.root',
    ]
+
+process.source.secondaryFileNames = []
+
+# create TFileService to be accessed by JRA-NTuple plugin
+process.TFileService = cms.Service('TFileService', fileName = cms.string(opts.output))
 
 # dump content of cms.Process to python file
 if opts.dumpPython is not None:
    open(opts.dumpPython, 'w').write(process.dumpPython())
 
-# print-outs
+# printouts
 if opts.verbosity > 0:
-   print '--- hltJRA_mcRun4_cfg.py ---'
+   print '--- jescJRA_cfg.py ---'
    print ''
    print 'option: output =', opts.output
    print 'option: reco =', opts.reco
@@ -243,69 +219,4 @@ if opts.verbosity > 0:
    print 'process.source =', process.source.dumpPython()
    print 'process.maxEvents =', process.maxEvents.dumpPython()
    print 'process.options =', process.options.dumpPython()
-   print '----------------------------'
-
-###
-### HLT configuration
-###
-if opts.reco == 'HLT_GRun':
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-
-elif opts.reco == 'HLT_Run3TRK':
-  # (a) Run-3 tracking: standard
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3Tracking
-  process = customizeHLTRun3Tracking(process)
-
-elif opts.reco == 'HLT_Run3TRKWithPU':
-  # (b) Run-3 tracking: all pixel vertices
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3TrackingAllPixelVertices
-  process = customizeHLTRun3TrackingAllPixelVertices(process)
-
-else:
-  raise RuntimeError('keyword "reco = '+opts.reco+'" not recognised')
-
-# remove cms.OutputModule objects from HLT config-dump
-for _modname in process.outputModules_():
-    _mod = getattr(process, _modname)
-    if type(_mod) == cms.OutputModule:
-       process.__delattr__(_modname)
-       if opts.verbosity > 0:
-          print '> removed cms.OutputModule:', _modname
-
-# remove cms.EndPath objects from HLT config-dump
-for _modname in process.endpaths_():
-    _mod = getattr(process, _modname)
-    if type(_mod) == cms.EndPath:
-       process.__delattr__(_modname)
-       if opts.verbosity > 0:
-          print '> removed cms.EndPath:', _modname
-
-# remove selected cms.Path objects from HLT config-dump
-print '-'*108
-print '{:<99} | {:<4} |'.format('cms.Path', 'keep')
-print '-'*108
-for _modname in sorted(process.paths_()):
-    _keepPath = _modname.startswith('MC_') and ('Jets' in _modname or 'MET' in _modname)
-    _keepPath |= _modname.startswith('MC_ReducedIterativeTracking')
-    if _keepPath:
-      print '{:<99} | {:<4} |'.format(_modname, '+')
-      continue
-    _mod = getattr(process, _modname)
-    if type(_mod) == cms.Path:
-      process.__delattr__(_modname)
-      print '{:<99} | {:<4} |'.format(_modname, '')
-print '-'*108
-
-# remove FastTimerService
-del process.FastTimerService
-
-# ###
-# ### customizations
-# ###
-# from JMETriggerAnalysis.Common.customise_hlt import *
-# process = addPath_MC_AK4PFClusterJets(process)
-# process = addPath_MC_AK4PFPuppiJets(process)
-
-
+   print '----------------------'

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,11 @@ git cms-merge-topic missirol:devel_1120pa_kineParticleFilter -u
 git cms-merge-topic missirol:devel_puppiPUProxy_1120patatrack -u
 git cms-merge-topic mmasciov:tracking-allPVs -u
 git clone https://github.com/missirol/JMETriggerAnalysis.git -o missirol -b run3
+
+# Run-3 PFHC: copy preliminary HLT-PFHC for Run-3
+mkdir -p ${CMSSW_BASE}/src/JMETriggerAnalysis/NTuplizers/data
+cp /afs/cern.ch/user/c/chuh/public/PFCalibration/run3/PFCalibration.db ${CMSSW_BASE}/src/JMETriggerAnalysis/NTuplizers/data/PFHC_Run3Winter20_HLT_v01.db
+
 scram b -j 12
 ```
 

--- a/setup_cmssw.sh
+++ b/setup_cmssw.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# recipe to set up local CMSSW area
+#
+# Notes:
+#  - do not use aliases (e.g. cmsrel, cmsenv),
+#    so that the recipe can also work in non-interactive shells
+#  - do not compile with scram inside this script
+#
+
+scramv1 project CMSSW_11_2_0_Patatrack
+cd CMSSW_11_2_0_Patatrack/src
+eval `scramv1 runtime -sh`
+
+git cms-merge-topic missirol:devel_1120pa_kineParticleFilter -u
+git cms-merge-topic missirol:devel_puppiPUProxy_1120patatrack -u
+git cms-merge-topic mmasciov:tracking-allPVs -u
+
+#git clone https://github.com/missirol/JMETriggerAnalysis.git -o missirol -b run3
+#
+## Run-3 PFHC: copy preliminary HLT-PFHC for Run-3
+#mkdir -p ${CMSSW_BASE}/src/JMETriggerAnalysis/NTuplizers/data
+#cp /afs/cern.ch/user/c/chuh/public/PFCalibration/run3/PFCalibration.db ${CMSSW_BASE}/src/JMETriggerAnalysis/NTuplizers/data/PFHC_Run3Winter20_HLT_v01.db


### PR DESCRIPTION
Run-3 updates including loading of latest PF-Hadron calibrations in config files of `NTuplizers/test/`.

Includes some simple fixes for ` NTuplizers/test/jescJRA_cfg.py`.

Note the updated instructions in the `readme`, to pick up the `.db` file for the PFHC inputs.

cc: @sparedes @cghuh