### PR TITLE
[JESCorrections] bugfix in test/fitJESCs for Run3Winter20_V2_MC

### DIFF
--- a/JESCorrections/test/fitJESCs
+++ b/JESCorrections/test/fitJESCs
@@ -106,6 +106,10 @@ runJECWorflowForOneAlgo(){
     skipL1=true
   fi
 
+  if [ "X${jetType}" = "Xak8puppiHLT" ]; then
+    skipL1=true
+  fi
+
   ###
   ### L1FastJet
   ###


### PR DESCRIPTION
* forcing skipping of L1 JEC for `ak8puppiHLT` collection
* will update the tag to include this fix

FYI: @sparedes @pallabidas