### PR TITLE
updates for PF-Hadron calibrations in 11_3_X

### DIFF
--- a/Common/test/dumpHLTMenus_mcRun3.sh
+++ b/Common/test/dumpHLTMenus_mcRun3.sh
@@ -1,16 +1,15 @@
-#!/bin/bash
+#!/bin/bash -e
 
-set -e
-
-hltGetConfiguration /dev/CMSSW_11_2_0/GRun/V19 \
+hltGetConfiguration /dev/CMSSW_11_3_0/GRun/V14 \
  --full \
  --offline \
  --unprescale \
- --process HLT2 \
- --globaltag 112X_mcRun3_2021_realistic_v13 \
- --input /store/mc/Run3Winter20DRMiniAOD/QCD_Pt-15to7000_TuneCP5_Flat_14TeV_pythia8/GEN-SIM-RAW/FlatPU0to80_110X_mcRun3_2021_realistic_v6-v1/130003/1D612E3B-8CAC-9D4B-B773-79C37D3F9D12.root \
+ --process HLTX \
+ --globaltag auto:run3_mc_GRun \
+ --input /store/mc/Run3Winter21DRMiniAOD/SinglePion_PT0to200/GEN-SIM-DIGI-RAW/NoPUFEVT_112X_mcRun3_2021_realistic_v16-v2/140000/53fc39b0-c12c-419f-ba73-78c4d032ff3e.root \
+ --mc \
  --max-events 10 \
  > tmp.py
 
-edmConfigDump tmp.py > ${CMSSW_BASE}/src/JMETriggerAnalysis/Common/python/configs/HLT_dev_CMSSW_11_2_0_GRun_V19_configDump.py
+edmConfigDump tmp.py > ${CMSSW_BASE}/src/JMETriggerAnalysis/Common/python/configs/HLT_dev_CMSSW_11_3_0_GRun_V14_configDump.py
 rm -f tmp.py

--- a/PFHadronCalibration/readme.md
+++ b/PFHadronCalibration/readme.md
@@ -1,0 +1,76 @@
+This directory contains tools and instructions
+to derive the PF-Hadron calibrations (PFHCs)
+used in the High-Level Trigger (HLT).
+
+#### Introduction
+
+ * General description of the calibration methods,
+   incl. references to the relevant documentation
+   (publications, analysis notes, presentations, webpages)
+
+#### Setup
+
+Instructions to set up the local CMSSW area:
+```
+scram project CMSSW CMSSW_11_3_1_patch1
+cd CMSSW_11_3_1_patch1/src
+eval `scram runtime -sh`
+git cms-init
+git clone https://github.com/missirol/JMETriggerAnalysis.git -o missirol -b run3
+scram b -j 8
+```
+
+#### Production of NTuples for PFHCs
+
+The first step to derive PFHCs is to create an NTuple with the relevant information for the calibration procedure.
+
+PFHCs are derived using MC events simulating
+the production of a single-pion without pileup (NoPU),
+with the generated pion $p_{T}$ usually restricted to values below 200 GeV.
+
+!! Add more details on how to find the relevant sample in DAS (e.g. look for `/*SinglePion*0*200*/*NoPU*/*RAW*`).
+
+!! Add information on what to do if a sample is not available at a Tier-2 (transfer request, Rucio rule)
+
+The first step in the calibration procedure is to create a flat ROOT NTuple
+containing information on selected HLT PF-Candidates,
+and the `PFSimParticle` candidates (truth-level information) associated to them.
+
+!! Add more details on how HLT PF-Candidates are selected, and matched to `PFSimParticle` candidates.
+
+To test the first step of the workflow, a small test NTuple can be produced locally as follows:
+```
+cmsRun ${CMSSW_BASE}/src/JMETriggerAnalysis/PFHadronCalibration/test/pfHadCalibNTuple_cfg.py maxEvents=1000
+```
+
+which contains information
+
+!! Add information on how to run the NTuple step with crab, HTCondor and/or other batch systems
+
+#### Derivation of PFHCs
+
+ * Given a set of input PFHC NTuples, how to analyse them to derive the PFHC functions
+ * How to produce final `.db` file containing the PFHCs
+
+#### Validation of PFHCs
+
+ * Given a set of PFHCs (i.e. a `.db` file containing the relevant records),
+   how to validate this output, and verify that the corrections work as expected
+
+#### Delivery of PFHCs
+
+ * How to upload the relevant records to the appropriate database
+ * How to integrate new PFHCs in a Global-Tag (GT)
+
+#### Available sets of PFHCs
+
+List of the available PFHCs for HLT,
+with the necessary metadata to be able to reproduce them if needed.
+This should include:
+ * `git` tag corresponding to the version of `JMETriggerAnalysis` used for the calibrations
+ * name of the CMSSW release used
+ * names of the datasets in DAS used for the calibrations
+ * link to the `cmsRun` configuration file used to create the PFHC-NTuples,
+ * links to the PFHC-NTuples used for the calibrations (if still available)
+ * link to the relevant analysis scripts to derive and validate the calibrations
+ * any further instructions specific to a certain PFHC version (if necessary)

--- a/PFHadronCalibration/test/pfHadCalibDBFile_cfg.py
+++ b/PFHadronCalibration/test/pfHadCalibDBFile_cfg.py
@@ -105,4 +105,4 @@ process.p = cms.Path(process.pfCalObj)
 
 # dump content of cms.Process to python file
 if opts.dumpPython is not None:
-   open(opts.dumpPython, 'w').write(process.dumpPython())
+  open(opts.dumpPython, 'w').write(process.dumpPython())

--- a/PFHadronCalibration/test/pfHadCalibNTuple_cfg.py
+++ b/PFHadronCalibration/test/pfHadCalibNTuple_cfg.py
@@ -45,30 +45,18 @@ opts.parseArguments()
 ### HLT configuration
 ###
 if opts.reco == 'HLT_GRun':
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-
-elif opts.reco == 'HLT_Run3TRK':
-  # (a) Run-3 tracking: standard
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3Tracking
-  process = customizeHLTRun3Tracking(process)
-
-elif opts.reco == 'HLT_Run3TRKWithPU':
-  # (b) Run-3 tracking: all pixel vertices
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3TrackingAllPixelVertices
-  process = customizeHLTRun3TrackingAllPixelVertices(process)
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_3_0_GRun_V14_configDump import cms, process
 
 else:
   raise RuntimeError('keyword "reco = '+opts.reco+'" not recognised')
 
 # remove cms.OutputModule objects from HLT config-dump
 for _modname in process.outputModules_():
-    _mod = getattr(process, _modname)
-    if type(_mod) == cms.OutputModule:
-       process.__delattr__(_modname)
-       if opts.verbosity > 0:
-          print '> removed cms.OutputModule:', _modname
+  _mod = getattr(process, _modname)
+  if type(_mod) == cms.OutputModule:
+    process.__delattr__(_modname)
+    if opts.verbosity > 0:
+      print '> removed cms.OutputModule:', _modname
 
 # remove cms.EndPath objects from HLT config-dump
 for _modname in process.endpaths_():
@@ -83,15 +71,15 @@ print '-'*108
 print '{:<99} | {:<4} |'.format('cms.Path', 'keep')
 print '-'*108
 for _modname in sorted(process.paths_()):
-    _keepPath = _modname.startswith('MC_') and ('Jets' in _modname or 'MET' in _modname)
-    _keepPath |= _modname.startswith('MC_ReducedIterativeTracking')
-    if _keepPath:
-      print '{:<99} | {:<4} |'.format(_modname, '+')
-      continue
-    _mod = getattr(process, _modname)
-    if type(_mod) == cms.Path:
-      process.__delattr__(_modname)
-      print '{:<99} | {:<4} |'.format(_modname, '')
+  _keepPath = _modname.startswith('MC_') and ('Jets' in _modname or 'MET' in _modname)
+  _keepPath |= _modname.startswith('MC_ReducedIterativeTracking')
+  if _keepPath:
+    print '{:<99} | {:<4} |'.format(_modname, '+')
+    continue
+  _mod = getattr(process, _modname)
+  if type(_mod) == cms.Path:
+    process.__delattr__(_modname)
+    print '{:<99} | {:<4} |'.format(_modname, '')
 print '-'*108
 
 # remove FastTimerService
@@ -176,7 +164,7 @@ if opts.inputFiles:
   process.source.fileNames = opts.inputFiles
 else:
   process.source.fileNames = [
-    '/store/mc/Run3Winter20DRMiniAOD/SinglePion_PT0to200/GEN-SIM-RAW/NoPU_ECal_FixNoPUIssue_110X_mcRun3_2021_realistic_v6-v2/280000/2B9E2D1C-48C6-AC4D-8464-2321A096354A.root',
+    '/store/mc/Run3Winter21DRMiniAOD/SinglePion_PT0to200/GEN-SIM-DIGI-RAW/NoPUFEVT_112X_mcRun3_2021_realistic_v16-v2/140000/53fc39b0-c12c-419f-ba73-78c4d032ff3e.root',
   ]
 
 # output file
@@ -184,5 +172,5 @@ process.TFileService = cms.Service('TFileService', fileName = cms.string(opts.ou
 
 # dump content of cms.Process to python file
 if opts.dumpPython is not None:
-   process.prune()
-   open(opts.dumpPython, 'w').write(process.dumpPython())
+  process.prune()
+  open(opts.dumpPython, 'w').write(process.dumpPython())

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,15 @@
+----------
+----------
+
+**Note**: for instructions on HLT PF-Hadron calibrations and Jet Energy Scale Corrections,
+please ignore this `readme`, and follow the instructions in the dedicated `readme` files:
+
+ * [`readme` for HLT PF-Hadron Calibrations](https://github.com/missirol/JMETriggerAnalysis/blob/run3/PFHadronCalibrations/readme.md)
+ * [`readme` for HLT Jet Energy Scale Corrections](https://github.com/missirol/JMETriggerAnalysis/blob/run3/JESCorrections/readme.md)
+
+----------
+----------
+
 ### Tools for JME studies on the Run-3 HLT reconstruction
 
 * [Tests on HLT Tracking for Run-3](#tests-on-hlt-tracking-for-run-3)
@@ -35,10 +47,10 @@ The baseline HLT menu for Run-3 in 11_2_X can be found in
 [Common/python/configs/HLT_dev_CMSSW_11_2_0_GRun_V19_configDump.py](https://github.com/missirol/JMETriggerAnalysis/blob/run3_devel_112X/Common/python/configs/HLT_dev_CMSSW_11_2_0_GRun_V19_configDump.py).
 
 It was created with `hltGetConfiguration` via the commands listed in
-[`Common/test/dumpHLTMenus_mcRun3.sh`](https://github.com/missirol/JMETriggerAnalysis/blob/run3_devel_112X/Common/test/dumpHLTMenus_mcRun3.sh).
+[`Common/test/dumpHLTMenus_mcRun3.sh`](https://github.com/missirol/JMETriggerAnalysis/blob/6a5807010c9934c25b0cb7bea22d7c90bbb87bc1/Common/test/dumpHLTMenus_mcRun3.sh).
 
 An example of how to enable the different tracking customisations can be found in
-[`NTuplizers/test/jmeTriggerNTuple_cfg.py`](https://github.com/missirol/JMETriggerAnalysis/blob/run3_devel_112X/NTuplizers/test/jmeTriggerNTuple_cfg.py)
+[`NTuplizers/test/jmeTriggerNTuple_cfg.py`](https://github.com/missirol/JMETriggerAnalysis/blob/6a5807010c9934c25b0cb7bea22d7c90bbb87bc1/Common/test/dumpHLTMenus_mcRun3.sh)
 (see option `reco`).
 Test commands:
 ```


### PR DESCRIPTION
This PR includes updates to run the PF-Hadron calibration procedure using an HLT menu in `11_3_X`.

The available instructions have been included in `PFHadronCalibration/readme.md`. The latter readme still contains several placeholders, and is to be updated with more complete information.

Attn: @cghuh @pallabidas
