### PR TITLE
updates for Run-3 studies in 12_0_0_pre4

### DIFF
--- a/Common/python/customise_hlt.py
+++ b/Common/python/customise_hlt.py
@@ -214,36 +214,40 @@ def addPaths_MC_JMEPFCluster(process):
       srcCorrections = cms.VInputTag('hltPFClusterMETCorrection:type1'),
     )
 
+    process.hltPFClusterJMETask = cms.Task(
+      ## AK4 Jets
+      process.hltAK4PFClusterJets,
+      process.hltFixedGridRhoFastjetAllPFCluster,
+      process.hltAK4PFClusterJetCorrectorL1,
+      process.hltAK4PFClusterJetCorrectorL2,
+      process.hltAK4PFClusterJetCorrectorL3,
+      process.hltAK4PFClusterJetCorrector,
+      process.hltAK4PFClusterJetsCorrected,
+      ## AK8 Jets
+      process.hltAK8PFClusterJets,
+      process.hltAK8PFClusterJetCorrectorL1,
+      process.hltAK8PFClusterJetCorrectorL2,
+      process.hltAK8PFClusterJetCorrectorL3,
+      process.hltAK8PFClusterJetCorrector,
+      process.hltAK8PFClusterJetsCorrected,
+      ## MET
+      process.hltPFClusterMET,
+      ## MET Type-1
+      process.hltPFClusterMETCorrection,
+      process.hltPFClusterMETTypeOne,
+    )
+
     process.MC_JMEPFCluster_v1 = cms.Path(
         process.HLTBeginSequence
       + process.hltPreMCJMEPFCluster
       + process.HLTParticleFlowClusterSequence
       + process.HLTParticleFlowClusterRefsSequence
-      ## AK4 Jets
-      + process.hltAK4PFClusterJets
-      + process.hltFixedGridRhoFastjetAllPFCluster
-      + process.hltAK4PFClusterJetCorrectorL1
-      + process.hltAK4PFClusterJetCorrectorL2
-      + process.hltAK4PFClusterJetCorrectorL3
-      + process.hltAK4PFClusterJetCorrector
-      + process.hltAK4PFClusterJetsCorrected
-      ## AK8 Jets
-      + process.hltAK8PFClusterJets
-      + process.hltAK8PFClusterJetCorrectorL1
-      + process.hltAK8PFClusterJetCorrectorL2
-      + process.hltAK8PFClusterJetCorrectorL3
-      + process.hltAK8PFClusterJetCorrector
-      + process.hltAK8PFClusterJetsCorrected
-      ## MET
-      + process.hltPFClusterMET
-      ## MET Type-1
-      + process.hltPFClusterMETCorrection
-      + process.hltPFClusterMETTypeOne
-      + process.HLTEndSequence
+      + process.HLTEndSequence,
+      process.hltPFClusterJMETask,
     )
 
     if process.schedule_():
-       process.schedule_().append(process.MC_JMEPFCluster_v1)
+      process.schedule_().append(process.MC_JMEPFCluster_v1)
 
     return process
 
@@ -332,13 +336,13 @@ def addPaths_MC_JMEPFCHS(process):
       correctors = cms.VInputTag('hltAK4PFCHSJetCorrector'),
     )
 
-    process.HLTAK4PFCHSJetsSequence = cms.Sequence(
-        process.hltAK4PFCHSJets
-      + process.hltAK4PFCHSJetCorrectorL1
-      + process.hltAK4PFCHSJetCorrectorL2
-      + process.hltAK4PFCHSJetCorrectorL3
-      + process.hltAK4PFCHSJetCorrector
-      + process.hltAK4PFCHSJetsCorrected
+    process.HLTAK4PFCHSJetsTask = cms.Task(
+      process.hltAK4PFCHSJets,
+      process.hltAK4PFCHSJetCorrectorL1,
+      process.hltAK4PFCHSJetCorrectorL2,
+      process.hltAK4PFCHSJetCorrectorL3,
+      process.hltAK4PFCHSJetCorrector,
+      process.hltAK4PFCHSJetsCorrected,
     )
 
     ## AK8
@@ -373,16 +377,16 @@ def addPaths_MC_JMEPFCHS(process):
       correctors = cms.VInputTag('hltAK8PFCHSJetCorrector'),
     )
 
-    process.HLTAK8PFCHSJetsSequence = cms.Sequence(
-        process.hltAK8PFCHSJets
-      + process.hltAK8PFCHSJetCorrectorL1
-      + process.hltAK8PFCHSJetCorrectorL2
-      + process.hltAK8PFCHSJetCorrectorL3
-      + process.hltAK8PFCHSJetCorrector
-      + process.hltAK8PFCHSJetsCorrected
+    process.HLTAK8PFCHSJetsTask = cms.Task(
+      process.hltAK8PFCHSJets,
+      process.hltAK8PFCHSJetCorrectorL1,
+      process.hltAK8PFCHSJetCorrectorL2,
+      process.hltAK8PFCHSJetCorrectorL3,
+      process.hltAK8PFCHSJetCorrector,
+      process.hltAK8PFCHSJetsCorrected,
     )
 
-    ## MET: CHS
+    ## MET
     process.hltParticleFlowCHS = cms.EDProducer('FwdPtrRecoPFCandidateConverter',
       src = process.hltAK4PFCHSJets.src,
     )
@@ -413,11 +417,11 @@ def addPaths_MC_JMEPFCHS(process):
     )
 
     ## Sequence: MET CHS
-    process.HLTPFCHSMETSequence = cms.Sequence(
-        process.hltParticleFlowCHS
-      + process.hltPFCHSMET
-      + process.hltPFCHSMETCorrection
-      + process.hltPFCHSMETTypeOne
+    process.HLTPFCHSMETTask = cms.Task(
+      process.hltParticleFlowCHS,
+      process.hltPFCHSMET,
+      process.hltPFCHSMETCorrection,
+      process.hltPFCHSMETTypeOne,
     )
 
     ## Path
@@ -425,14 +429,14 @@ def addPaths_MC_JMEPFCHS(process):
         process.HLTBeginSequence
       + process.hltPreMCJMEPFCHS
       + process.HLTPFCHSSequence
-      + process.HLTAK4PFCHSJetsSequence
-      + process.HLTAK8PFCHSJetsSequence
-      + process.HLTPFCHSMETSequence
-      + process.HLTEndSequence
+      + process.HLTEndSequence,
+      process.HLTAK4PFCHSJetsTask,
+      process.HLTAK8PFCHSJetsTask,
+      process.HLTPFCHSMETTask,
     )
 
     if process.schedule_():
-       process.schedule_().append(process.MC_JMEPFCHS_v1)
+      process.schedule_().append(process.MC_JMEPFCHS_v1)
 
     return process
 
@@ -499,13 +503,13 @@ def addPaths_MC_JMEPFPuppi(process):
       correctors = cms.VInputTag('hltAK4PFPuppiJetCorrector'),
     )
 
-    process.HLTAK4PFPuppiJetsSequence = cms.Sequence(
-        process.hltAK4PFPuppiJets
-      + process.hltAK4PFPuppiJetCorrectorL1
-      + process.hltAK4PFPuppiJetCorrectorL2
-      + process.hltAK4PFPuppiJetCorrectorL3
-      + process.hltAK4PFPuppiJetCorrector
-      + process.hltAK4PFPuppiJetsCorrected
+    process.HLTAK4PFPuppiJetsTask = cms.Task(
+      process.hltAK4PFPuppiJets,
+      process.hltAK4PFPuppiJetCorrectorL1,
+      process.hltAK4PFPuppiJetCorrectorL2,
+      process.hltAK4PFPuppiJetCorrectorL3,
+      process.hltAK4PFPuppiJetCorrector,
+      process.hltAK4PFPuppiJetsCorrected,
     )
 
     ## AK8
@@ -544,13 +548,13 @@ def addPaths_MC_JMEPFPuppi(process):
       correctors = cms.VInputTag('hltAK8PFPuppiJetCorrector'),
     )
 
-    process.HLTAK8PFPuppiJetsSequence = cms.Sequence(
-        process.hltAK8PFPuppiJets
-      + process.hltAK8PFPuppiJetCorrectorL1
-      + process.hltAK8PFPuppiJetCorrectorL2
-      + process.hltAK8PFPuppiJetCorrectorL3
-      + process.hltAK8PFPuppiJetCorrector
-      + process.hltAK8PFPuppiJetsCorrected
+    process.HLTAK8PFPuppiJetsTask = cms.Task(
+      process.hltAK8PFPuppiJets,
+      process.hltAK8PFPuppiJetCorrectorL1,
+      process.hltAK8PFPuppiJetCorrectorL2,
+      process.hltAK8PFPuppiJetCorrectorL3,
+      process.hltAK8PFPuppiJetCorrector,
+      process.hltAK8PFPuppiJetsCorrected,
     )
 
     ## MET
@@ -569,11 +573,6 @@ def addPaths_MC_JMEPFPuppi(process):
       parameters = cms.PSet(),
       src = cms.InputTag('hltParticleFlow'),
       srcWeights = cms.InputTag('hltPFPuppiNoLep'),
-    )
-
-    process.HLTPFPuppiMETSequence = cms.Sequence(
-        process.hltPFPuppiNoLep
-      + process.hltPFPuppiMET
     )
 
     ## MET Type-1
@@ -595,6 +594,13 @@ def addPaths_MC_JMEPFPuppi(process):
       srcCorrections = cms.VInputTag('hltPFPuppiMETCorrection:type1'),
     )
 
+    process.HLTPFPuppiMETTask = cms.Task(
+      process.hltPFPuppiNoLep,
+      process.hltPFPuppiMET,
+      process.hltPFPuppiMETCorrection,
+      process.hltPFPuppiMETTypeOne,
+    )
+
     ## Modifications to PUPPI parameters
     for mod_i in [process.hltPFPuppi, process.hltPFPuppiNoLep]:
       for algo_idx in range(len(mod_i.algos)):
@@ -609,19 +615,14 @@ def addPaths_MC_JMEPFPuppi(process):
     process.MC_JMEPFPuppi_v1 = cms.Path(
         process.HLTBeginSequence
       + process.hltPreMCJMEPFPuppi
-      ## AK{4,8} Jets
       + process.HLTPFPuppiSequence
-      + process.HLTAK4PFPuppiJetsSequence
-      + process.HLTAK8PFPuppiJetsSequence
-      ## MET
-      + process.HLTPFPuppiMETSequence
-      ## MET Type-1
-      + process.hltPFPuppiMETCorrection
-      + process.hltPFPuppiMETTypeOne
-      + process.HLTEndSequence
+      + process.HLTEndSequence,
+      process.HLTAK4PFPuppiJetsTask,
+      process.HLTAK8PFPuppiJetsTask,
+      process.HLTPFPuppiMETTask,
     )
 
     if process.schedule_():
-       process.schedule_().append(process.MC_JMEPFPuppi_v1)
+      process.schedule_().append(process.MC_JMEPFPuppi_v1)
 
     return process

--- a/Common/test/dumpHLTMenus_mcRun3.sh
+++ b/Common/test/dumpHLTMenus_mcRun3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-hltGetConfiguration /dev/CMSSW_11_3_0/GRun/V14 \
+hltGetConfiguration /dev/CMSSW_12_0_0/HLT/V4 \
  --full \
  --offline \
  --unprescale \
@@ -11,5 +11,5 @@ hltGetConfiguration /dev/CMSSW_11_3_0/GRun/V14 \
  --max-events 10 \
  > tmp.py
 
-edmConfigDump tmp.py > ${CMSSW_BASE}/src/JMETriggerAnalysis/Common/python/configs/HLT_dev_CMSSW_11_3_0_GRun_V14_configDump.py
+edmConfigDump tmp.py > ${CMSSW_BASE}/src/JMETriggerAnalysis/Common/python/configs/HLT_dev_CMSSW_12_0_0_HLT_V4_configDump.py
 rm -f tmp.py

--- a/JESCorrections/test/jescJRA_cfg.py
+++ b/JESCorrections/test/jescJRA_cfg.py
@@ -41,7 +41,7 @@ opts.register('wantSummary', False,
 #              vpo.VarParsing.varType.string,
 #              'argument of process.GlobalTag.globaltag')
 
-opts.register('reco', 'HLT_GRun',
+opts.register('reco', 'HLT_Run3TRK',
               vpo.VarParsing.multiplicity.singleton,
               vpo.VarParsing.varType.string,
               'keyword to define HLT reconstruction')
@@ -62,19 +62,19 @@ opts.parseArguments()
 ### HLT configuration
 ###
 if opts.reco == 'HLT_GRun':
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
 
 elif opts.reco == 'HLT_Run3TRK':
   # (a) Run-3 tracking: standard
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3Tracking
-  process = customizeHLTRun3Tracking(process)
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
+  from HLTrigger.Configuration.customizeHLTforRun3Tracking import customizeHLTforRun3Tracking
+  process = customizeHLTforRun3Tracking(process)
 
 elif opts.reco == 'HLT_Run3TRKWithPU':
   # (b) Run-3 tracking: all pixel vertices
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3TrackingAllPixelVertices
-  process = customizeHLTRun3TrackingAllPixelVertices(process)
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
+  from HLTrigger.Configuration.customizeHLTforRun3Tracking import customizeHLTforRun3TrackingAllPixelVertices
+  process = customizeHLTforRun3TrackingAllPixelVertices(process)
 
 else:
   raise RuntimeError('keyword "reco = '+opts.reco+'" not recognised')
@@ -85,7 +85,7 @@ for _modname in process.outputModules_():
   if type(_mod) == cms.OutputModule:
     process.__delattr__(_modname)
     if opts.verbosity > 0:
-      print '> removed cms.OutputModule:', _modname
+      print('> removed cms.OutputModule:', _modname)
 
 # remove cms.EndPath objects from HLT config-dump
 for _modname in process.endpaths_():
@@ -93,14 +93,14 @@ for _modname in process.endpaths_():
   if type(_mod) == cms.EndPath:
     process.__delattr__(_modname)
     if opts.verbosity > 0:
-      print '> removed cms.EndPath:', _modname
+      print('> removed cms.EndPath:', _modname)
 
 # remove selected cms.Path objects from HLT config-dump
-print '-'*108
-print '{:<99} | {:<4} |'.format('cms.Path', 'keep')
-print '-'*108
+print('-'*108)
+print('{:<99} | {:<4} |'.format('cms.Path', 'keep'))
+print('-'*108)
 
-# list of patterns to determine paths to keep
+# list of patterns to determine which paths to keep
 keepPaths = [
   'MC_*Jets*',
   'MC_*AK8Calo*',
@@ -112,13 +112,13 @@ for _modname in sorted(process.paths_()):
     _keepPath = fnmatch.fnmatch(_modname, _tmpPatt)
     if _keepPath: break
   if _keepPath:
-    print '{:<99} | {:<4} |'.format(_modname, '+')
+    print('{:<99} | {:<4} |'.format(_modname, '+'))
     continue
   _mod = getattr(process, _modname)
   if type(_mod) == cms.Path:
     process.__delattr__(_modname)
-    print '{:<99} | {:<4} |'.format(_modname, '')
-print '-'*108
+    print('{:<99} | {:<4} |'.format(_modname, ''))
+print('-'*108)
 
 # remove FastTimerService
 if hasattr(process, 'FastTimerService'):
@@ -140,6 +140,7 @@ process = addPaths_MC_JMEPFPuppi(process)
 
 ## ES modules for PF-Hadron Calibrations
 import os
+
 from CondCore.CondDB.CondDB_cfi import CondDB as _CondDB
 process.pfhcESSource = cms.ESSource('PoolDBESSource',
   _CondDB.clone(connect = 'sqlite_file:'+os.environ['CMSSW_BASE']+'/src/JMETriggerAnalysis/NTuplizers/data/PFHC_Run3Winter20_HLT_v01.db'),
@@ -153,6 +154,64 @@ process.pfhcESSource = cms.ESSource('PoolDBESSource',
 )
 process.pfhcESPrefer = cms.ESPrefer('PoolDBESSource', 'pfhcESSource')
 #process.hltParticleFlow.calibrationsLabel = '' # standard label for Offline-PFHC in GT
+
+## ES modules for HLT JECs
+process.jescESSource = cms.ESSource('PoolDBESSource',
+  _CondDB.clone(connect = 'sqlite_file:'+os.environ['CMSSW_BASE']+'/src/JMETriggerAnalysis/NTuplizers/data/JESC_Run3Winter20_V2_MC.db'),
+  toGet = cms.VPSet(
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4CaloHLT'),
+      label = cms.untracked.string('AK4CaloHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFClusterHLT'),
+      label = cms.untracked.string('AK4PFClusterHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFHLT'),
+      label = cms.untracked.string('AK4PFHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFHLT'),#!!
+      label = cms.untracked.string('AK4PFchsHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFPuppiHLT'),
+      label = cms.untracked.string('AK4PFPuppiHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8CaloHLT'),
+      label = cms.untracked.string('AK8CaloHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFClusterHLT'),
+      label = cms.untracked.string('AK8PFClusterHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFHLT'),
+      label = cms.untracked.string('AK8PFHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFHLT'),#!!
+      label = cms.untracked.string('AK8PFchsHLT'),
+    ),
+    cms.PSet(
+      record = cms.string('JetCorrectionsRecord'),
+      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFPuppiHLT'),
+      label = cms.untracked.string('AK8PFPuppiHLT'),
+    ),
+  ),
+)
+process.jescESPrefer = cms.ESPrefer('PoolDBESSource', 'jescESSource')
 
 ###
 ### Jet Response Analyzer (JRA) NTuple
@@ -221,14 +280,14 @@ if opts.dumpPython is not None:
 
 # printouts
 if opts.verbosity > 0:
-   print '--- jescJRA_cfg.py ---'
-   print ''
-   print 'option: output =', opts.output
-   print 'option: reco =', opts.reco
-   print 'option: dumpPython =', opts.dumpPython
-   print ''
-   print 'process.GlobalTag =', process.GlobalTag.dumpPython()
-   print 'process.source =', process.source.dumpPython()
-   print 'process.maxEvents =', process.maxEvents.dumpPython()
-   print 'process.options =', process.options.dumpPython()
-   print '----------------------'
+   print('--- jescJRA_cfg.py ---')
+   print('')
+   print('option: output =', opts.output)
+   print('option: reco =', opts.reco)
+   print('option: dumpPython =', opts.dumpPython)
+   print('')
+   print('process.GlobalTag =', process.GlobalTag.dumpPython())
+   print('process.source =', process.source.dumpPython())
+   print('process.maxEvents =', process.maxEvents.dumpPython())
+   print('process.options =', process.options.dumpPython())
+   print('----------------------')

--- a/JESCorrections/test/jescJRA_cfg.py
+++ b/JESCorrections/test/jescJRA_cfg.py
@@ -155,64 +155,6 @@ process.pfhcESSource = cms.ESSource('PoolDBESSource',
 process.pfhcESPrefer = cms.ESPrefer('PoolDBESSource', 'pfhcESSource')
 #process.hltParticleFlow.calibrationsLabel = '' # standard label for Offline-PFHC in GT
 
-## ES modules for HLT JECs
-process.jescESSource = cms.ESSource('PoolDBESSource',
-  _CondDB.clone(connect = 'sqlite_file:'+os.environ['CMSSW_BASE']+'/src/JMETriggerAnalysis/NTuplizers/data/JESC_Run3Winter20_V2_MC.db'),
-  toGet = cms.VPSet(
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4CaloHLT'),
-      label = cms.untracked.string('AK4CaloHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFClusterHLT'),
-      label = cms.untracked.string('AK4PFClusterHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFHLT'),
-      label = cms.untracked.string('AK4PFHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFHLT'),#!!
-      label = cms.untracked.string('AK4PFchsHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK4PFPuppiHLT'),
-      label = cms.untracked.string('AK4PFPuppiHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8CaloHLT'),
-      label = cms.untracked.string('AK8CaloHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFClusterHLT'),
-      label = cms.untracked.string('AK8PFClusterHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFHLT'),
-      label = cms.untracked.string('AK8PFHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFHLT'),#!!
-      label = cms.untracked.string('AK8PFchsHLT'),
-    ),
-    cms.PSet(
-      record = cms.string('JetCorrectionsRecord'),
-      tag = cms.string('JetCorrectorParametersCollection_Run3Winter20_V2_MC_AK8PFPuppiHLT'),
-      label = cms.untracked.string('AK8PFPuppiHLT'),
-    ),
-  ),
-)
-process.jescESPrefer = cms.ESPrefer('PoolDBESSource', 'jescESSource')
-
 ###
 ### Jet Response Analyzer (JRA) NTuple
 ###

--- a/NTuplizers/plugins/BuildFile.xml
+++ b/NTuplizers/plugins/BuildFile.xml
@@ -12,6 +12,8 @@
   <use name="DataFormats/Common"/>
   <use name="DataFormats/L1TGlobal"/>
   <use name="HLTrigger/HLTcore"/>
+  <use name="SimDataFormats/GeneratorProducts"/>
+  <use name="SimDataFormats/PileupSummaryInfo"/>
   <use name="rootmath"/>
   <use name="root"/>
 </library>

--- a/NTuplizers/plugins/TriggerFlagsProducer.cc
+++ b/NTuplizers/plugins/TriggerFlagsProducer.cc
@@ -9,8 +9,8 @@
 #include "DataFormats/L1TGlobal/interface/GlobalLogicParser.h"
 #include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 
-#include <iostream>
-#define LogTrace(X) std::cout << std::endl
+//#include <iostream>
+//#define LogTrace(X) std::cout << std::endl
 
 class TriggerFlagsProducer : public edm::stream::EDProducer<> {
 public:

--- a/NTuplizers/python/utils/common.py
+++ b/NTuplizers/python/utils/common.py
@@ -168,7 +168,7 @@ def HTCondor_jobExecutables_old(username=None):
 
     return _condorq_jobExes
 
-def HTCondor_jobExecutables_2(username=None):
+def HTCondor_jobExecutables(username=None):
     if not username:
        if 'USER' in os.environ: username = os.environ['USER']
 

--- a/NTuplizers/scripts/bdriver
+++ b/NTuplizers/scripts/bdriver
@@ -197,8 +197,8 @@ if __name__ == '__main__':
    if not os.path.isfile(voms_proxy_path):
      KILL(log_prx+'invalid path to voms proxy: '+voms_proxy_path)
 
+   OUTPUT_DIR_FINAL = OUTPUT_DIR
    if opts.batch_system == 'slurm':
-     OUTPUT_DIR_FINAL = OUTPUT_DIR
      OUTPUT_DIR = '.tmp'
      while os.path.exists(OUTPUT_DIR):
        OUTPUT_DIR += 'x'

--- a/NTuplizers/test/jmeTriggerNTuple_cfg.py
+++ b/NTuplizers/test/jmeTriggerNTuple_cfg.py
@@ -43,7 +43,7 @@ opts.register('wantSummary', False,
 #              vpo.VarParsing.varType.string,
 #              'argument of process.GlobalTag.globaltag')
 
-opts.register('reco', 'HLT_GRun',
+opts.register('reco', 'HLT_Run3TRK',
               vpo.VarParsing.multiplicity.singleton,
               vpo.VarParsing.varType.string,
               'keyword to define HLT reconstruction')
@@ -74,25 +74,25 @@ opts.parseArguments()
 ### HLT configuration
 ###
 if opts.reco == 'HLT_GRun_oldJECs':
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
   update_jmeCalibs = False
 
 elif opts.reco == 'HLT_GRun':
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
   update_jmeCalibs = True
 
 elif opts.reco == 'HLT_Run3TRK':
   # (a) Run-3 tracking: standard
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3Tracking
-  process = customizeHLTRun3Tracking(process)
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
+  from HLTrigger.Configuration.customizeHLTforRun3Tracking import customizeHLTforRun3Tracking
+  process = customizeHLTforRun3Tracking(process)
   update_jmeCalibs = True
 
 elif opts.reco == 'HLT_Run3TRKWithPU':
   # (b) Run-3 tracking: all pixel vertices
-  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_11_2_0_GRun_V19_configDump import cms, process
-  from HLTrigger.Configuration.customizeHLTRun3Tracking import customizeHLTRun3TrackingAllPixelVertices
-  process = customizeHLTRun3TrackingAllPixelVertices(process)
+  from JMETriggerAnalysis.Common.configs.HLT_dev_CMSSW_12_0_0_HLT_V4_configDump import cms, process
+  from HLTrigger.Configuration.customizeHLTforRun3Tracking import customizeHLTforRun3TrackingAllPixelVertices
+  process = customizeHLTforRun3TrackingAllPixelVertices(process)
   update_jmeCalibs = True
 
 else:
@@ -104,7 +104,7 @@ for _modname in process.outputModules_():
     if type(_mod) == cms.OutputModule:
        process.__delattr__(_modname)
        if opts.verbosity > 0:
-          print '> removed cms.OutputModule:', _modname
+          print('> removed cms.OutputModule:', _modname)
 
 # remove cms.EndPath objects from HLT config-dump
 for _modname in process.endpaths_():
@@ -112,12 +112,12 @@ for _modname in process.endpaths_():
     if type(_mod) == cms.EndPath:
        process.__delattr__(_modname)
        if opts.verbosity > 0:
-          print '> removed cms.EndPath:', _modname
+          print('> removed cms.EndPath:', _modname)
 
 # remove selected cms.Path objects from HLT config-dump
-print '-'*108
-print '{:<99} | {:<4} |'.format('cms.Path', 'keep')
-print '-'*108
+print('-'*108)
+print('{:<99} | {:<4} |'.format('cms.Path', 'keep'))
+print('-'*108)
 
 # list of patterns to determine paths to keep
 keepPaths = [
@@ -131,6 +131,10 @@ keepPaths = [
   'HLT_PFMET*_PFMHT*_v*',
 ]
 
+vetoPaths = [
+  'HLT_*ForPPRef_v*',
+]
+
 # list of paths that are kept
 listOfPaths = []
 
@@ -139,15 +143,22 @@ for _modname in sorted(process.paths_()):
     for _tmpPatt in keepPaths:
       _keepPath = fnmatch.fnmatch(_modname, _tmpPatt)
       if _keepPath: break
+
     if _keepPath:
-      print '{:<99} | {:<4} |'.format(_modname, '+')
+      for _tmpPatt in vetoPaths:
+        if fnmatch.fnmatch(_modname, _tmpPatt):
+          _keepPath = False
+          break
+
+    if _keepPath:
+      print('{:<99} | {:<4} |'.format(_modname, '+'))
       listOfPaths.append(_modname)
       continue
     _mod = getattr(process, _modname)
     if type(_mod) == cms.Path:
       process.__delattr__(_modname)
-      print '{:<99} | {:<4} |'.format(_modname, '')
-print '-'*108
+      print('{:<99} | {:<4} |'.format(_modname, ''))
+print('-'*108)
 
 # remove FastTimerService
 if hasattr(process, 'FastTimerService'):
@@ -510,14 +521,14 @@ if opts.dumpPython is not None:
 
 # printouts
 if opts.verbosity > 0:
-   print '--- jmeTriggerNTuple_cfg.py ---'
-   print ''
-   print 'option: output =', opts.output
-   print 'option: reco =', opts.reco
-   print 'option: dumpPython =', opts.dumpPython
-   print ''
-   print 'process.GlobalTag =', process.GlobalTag.dumpPython()
-   print 'process.source =', process.source.dumpPython()
-   print 'process.maxEvents =', process.maxEvents.dumpPython()
-   print 'process.options =', process.options.dumpPython()
-   print '-------------------------------'
+   print('--- jmeTriggerNTuple_cfg.py ---')
+   print('')
+   print('option: output =', opts.output)
+   print('option: reco =', opts.reco)
+   print('option: dumpPython =', opts.dumpPython)
+   print('')
+   print('process.GlobalTag =', process.GlobalTag.dumpPython())
+   print('process.source =', process.source.dumpPython())
+   print('process.maxEvents =', process.maxEvents.dumpPython())
+   print('process.options =', process.options.dumpPython())
+   print('-------------------------------')

--- a/readme.md
+++ b/readme.md
@@ -19,12 +19,14 @@ please ignore this `readme`, and follow the instructions in the dedicated `readm
 ### Tests on HLT Tracking for Run-3
 
 ```
-cmsrel CMSSW_11_2_0_Patatrack
-cd CMSSW_11_2_0_Patatrack/src
+cmsrel CMSSW_12_0_0_pre4
+cd CMSSW_12_0_0_pre4/src
 cmsenv
-git cms-merge-topic missirol:devel_1120pa_kineParticleFilter -u
-git cms-merge-topic missirol:devel_puppiPUProxy_1120patatrack -u
-git cms-merge-topic mmasciov:tracking-allPVs -u
+git cms-addpkg HLTrigger/Configuration
+git cms-addpkg CommonTools/RecoAlgos
+git cms-remote add mmasciov
+git fetch mmasciov
+git diff a0c27eab5ee^^ a0c27eab5ee | git apply
 git clone https://github.com/missirol/JMETriggerAnalysis.git -o missirol -b run3
 
 # external data

--- a/readme.md
+++ b/readme.md
@@ -22,12 +22,10 @@ please ignore this `readme`, and follow the instructions in the dedicated `readm
 cmsrel CMSSW_12_0_0_pre4
 cd CMSSW_12_0_0_pre4/src
 cmsenv
-git cms-addpkg HLTrigger/Configuration
-git cms-addpkg CommonTools/RecoAlgos
-git cms-remote add mmasciov
-git fetch mmasciov
-git diff a0c27eab5ee^^ a0c27eab5ee | git apply
-git clone https://github.com/missirol/JMETriggerAnalysis.git -o missirol -b run3
+git cms-merge-topic missirol:devel_hltRun3TRK_1200pre4
+
+git clone https://github.com/missirol/JMETriggerAnalysis.git -o missirol -b run3_devel
+git clone https://github.com/missirol/JetMETAnalysis.git -o missirol -b devel_hlt2
 
 # external data
 mkdir -p ${CMSSW_BASE}/src/JMETriggerAnalysis/NTuplizers/data
@@ -39,8 +37,6 @@ cp /afs/cern.ch/work/m/missirol/public/run3/PFHC/PFHC_Run3Winter20_HLT_v01.db \
 # JESC: preliminary HLT-JESCs for Run-3
 cp /afs/cern.ch/work/m/missirol/public/run3/JESC/Run3Winter20_V2_MC/Run3Winter20_V2_MC.db \
    ${CMSSW_BASE}/src/JMETriggerAnalysis/NTuplizers/data/JESC_Run3Winter20_V2_MC.db
-
-git clone https://github.com/missirol/JetMETAnalysis.git -o missirol -b run3_jrantuples
 
 scram b -j 12
 ```

--- a/setup_cmssw.sh
+++ b/setup_cmssw.sh
@@ -9,10 +9,11 @@
 #  - do not compile with scram inside this script
 #
 
-scram project CMSSW_11_2_0_Patatrack
-cd CMSSW_11_2_0_Patatrack/src
+scram project CMSSW_12_0_0_pre4
+cd CMSSW_12_0_0_pre4/src
 eval `scram runtime -sh`
-
-git cms-merge-topic missirol:devel_1120pa_kineParticleFilter -u
-git cms-merge-topic missirol:devel_puppiPUProxy_1120patatrack -u
-git cms-merge-topic mmasciov:tracking-allPVs -u
+git cms-addpkg HLTrigger/Configuration
+git cms-addpkg CommonTools/RecoAlgos
+git cms-remote add mmasciov
+git fetch mmasciov
+git diff a0c27eab5ee^^ a0c27eab5ee | git apply

--- a/setup_cmssw.sh
+++ b/setup_cmssw.sh
@@ -12,8 +12,4 @@
 scram project CMSSW_12_0_0_pre4
 cd CMSSW_12_0_0_pre4/src
 eval `scram runtime -sh`
-git cms-addpkg HLTrigger/Configuration
-git cms-addpkg CommonTools/RecoAlgos
-git cms-remote add mmasciov
-git fetch mmasciov
-git diff a0c27eab5ee^^ a0c27eab5ee | git apply
+git cms-merge-topic missirol:devel_hltRun3TRK_1200pre4


### PR DESCRIPTION
* updated recipe for Run-3 studies in `12_0_0_pre4`
* recipe for HLT Run-3 tracking does not work out-of-the-box in this release, so some necessary workarounds and fixes were included in `missirol/cmssw:devel_hltRun3TRK_1200pre4` (see readme)
* includes a couple of bugfixes for batch-job workflow with HTCondor (introduced when support for SLURM was added)

FYI: @pallabidas